### PR TITLE
Enable simple uploading with presigned URLs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,19 @@
 # ArtifactDB on the Cloudflare stack
 
+## Overview
+
 **gypsum** uses Cloudflare workers and R2 storage to provide a bare-bones deployment of an ArtifactDB API.
+This currently supports only the most basic of endpoints:
+
+- `/files/{id}` to retrieve presigned URLs to the file artifact `id`.
+- `/files/{id}/metadata` to retrieve the metadata of `id` as a JSON.
+
+## Deployment
+
+Deployment requires the specification of the R2 parameters:
+
+- `ACCOUNT_ID`, for the R2 account ID.
+- `ACCESS_KEY_ID`, for the access key ID.
+- `SECRET_ACCESS_KEY`, for the access secret.
+
+These can be specified in the browser or via `wrangler secret put`.

--- a/index.js
+++ b/index.js
@@ -1,6 +1,11 @@
 import { Router } from 'itty-router'
 import S3 from 'aws-sdk/clients/s3.js';
 
+import * as gh from "./src/github.js";
+import * as auth from "./src/auth.js";
+import * as upload from "./src/upload.js";
+import * as utils from "./src/utils.js";
+
 const s3 = new S3({
   endpoint: `https://${ACCOUNT_ID}.r2.cloudflarestorage.com`,
   accessKeyId: `${ACCESS_KEY_ID}`,
@@ -10,10 +15,6 @@ const s3 = new S3({
 
 const bucket_name = "gypsum-test";
 const router = Router()
-
-const github_api = "https://api.github.com";
-const github_repo = "ArtifactDB/gypsum-actions";
-const github_agent = "gypsum-test-worker";
 
 /*** CORS-related shenanigans ***/
 
@@ -41,66 +42,6 @@ function handleOptions(request) {
     }
 }
 
-/*** Miscellaneous functions ***/
-
-function unpackId(id) {
-    let i1 = id.indexOf(":");
-    if (i1 < 0) {
-        throw new Error("could not identify project from 'id'");
-    } else if (i1 == 0) {
-        throw new Error("'id' should not have an empty project");
-    }
-
-    let i2 = id.lastIndexOf("@");
-    if (i2 < 0) {
-        throw new Error("could not identify version from 'id'");
-    } else if (i2 == id.length - 1) {
-        throw new Error("'id' should not have an empty version");
-    }
-
-    if (i2 < i1) {
-        throw new Error("could not identify version from 'id'");
-    } else if (i1 +1 == i2){
-        throw new Error("'id' should not have an empty path");
-    }
-
-    return {
-        project: id.slice(0, i1),
-        path: id.slice(i1+1, i2),
-        version: id.slice(i2+1)
-    };
-}
-
-function errorResponse(reason, code) {
-    return new Response(
-        JSON.stringify({ 
-            "status": "error", 
-            "reason": reason
-        }),
-        { 
-            status: code, 
-            headers: {
-                "Content-Type": "application/json"
-            }
-        }
-    );
-}
-
-async function forwarder(project, path, version, content_type) {
-    let r2path = project + "/" + version + "/" + path;
-    let res = await GYPSUM_BUCKET.get(r2path);
-    if (res === null) {
-        return errorResponse("key '" + id + "' does not exist", 404);
-    }
-
-    let { readable, writable } = new TransformStream();
-    res.body.pipeTo(writable);
-
-    let output = new Response(readable, res);
-    output.headers.set("Content-Type", content_type);
-    return output;
-}
-
 /*** Setting up the routes ***/
 
 router.get("/files/:id/metadata", async ({params}) => {
@@ -116,7 +57,19 @@ router.get("/files/:id/metadata", async ({params}) => {
     if (!unpacked.path.endsWith(".json")) {
         unpacked.path += ".json";
     }
-    return forwarder(unpacked.project, unpacked.path, unpacked.version, "application/json");
+
+    let r2path = project + "/" + version + "/" + path;
+    let res = await GYPSUM_BUCKET.get(r2path);
+    if (res === null) {
+        return errorResponse("key '" + id + "' does not exist", 404);
+    }
+
+    let { readable, writable } = new TransformStream();
+    res.body.pipeTo(writable);
+
+    let output = new Response(readable, res);
+    output.headers.set("Content-Type", "application/json");
+    return output;
 })
 
 router.get("/files/:id", async({params, query}) => {
@@ -138,112 +91,11 @@ router.get("/files/:id", async({params, query}) => {
     return Response.redirect(target, 302);
 })
 
-router.post("/projects/:id/version/:version/upload", async request => {
-    let id = request.params.id;
-    let version = request.params.version;
+router.post("/projects/:id/version/:version/upload", request => upload.initializeUploadHandler(request, bucket_name, s3));
 
-    let body = await request.json();
-    let files = body.filenames;
+router.put("/projects/:id/version/:version/complete", request => upload.completeUploadHandler(request, GITHUB_PAT));
 
-    let precollected = [];
-    let prenames = []
-    for (const f of files) {
-        if (typeof f == "string") {
-            let params = { Bucket: bucket_name, Key: id + "/" + version + "/" + f, Expires: 3600 };
-            if (f.endsWith(".json")) {
-                params.ContentType = "application/json";
-            }
-            precollected.push(s3.getSignedUrlPromise('putObject', params));
-            prenames.push(f);
-        } else {
-            return errorResponse("non-string file uploads are not yet supported", 400);
-        }
-    }
-
-    let presigned_vec = await Promise.all(precollected);
-    let presigned = {};
-    for (var i = 0; i < presigned_vec.length; i++) {
-        presigned[prenames[i]] = presigned_vec[i];
-    }
-
-    return new Response(
-        JSON.stringify({ 
-            presigned_urls: presigned,
-            completion_url: "/projects/" + id + "/version/" + version + "/complete"
-        }),
-        {
-            status: 200,
-            headers: {
-                "Content-Type": "application/json"
-            }
-        }
-    );
-})
-
-router.put("/projects/:id/version/:version/complete", async request => {
-    let id = request.params.id;
-    let version = request.params.version;
-
-    // Permissions are handled by the indexer.
-    let perms = await request.json();
-
-    let URL = github_api + "/repos/" + github_repo + "/issues";
-
-    let res = await fetch(URL, {
-        method: "POST",
-        headers: {
-            'Content-Type': 'application/json',
-            "Authorization": "Bearer " + GITHUB_PAT,
-            "User-Agent": github_agent
-        },
-        body: JSON.stringify({
-            title: "upload complete",
-            body: JSON.stringify({ 
-                id: id,
-                version: version,
-                timestamp: Date.now(),
-                permissions: perms
-            })
-        })
-    });
-    if (!res.ok) {
-        return new errorReponse("failed to trigger GitHub Actions for indexing", { status: 500 });
-    }
-
-    let payload = await res.json();
-    return new Reponse({ job_id: payload.id }, { status: 204 });
-})
-
-router.get("/jobs/:jobid", async ({params}) => {
-    let jid = params.jobid;
-    let URL = github_api + "/repos/" + github_repo + "/issues/" + jid;
-
-    let res = await fetch(URL, {
-        headers: {
-            "Authorization": "Bearer " + GITHUB_PAT,
-            "User-Agent": github_agent
-        }
-    });
-    if (!res.ok) {
-        return errorResponse("failed to query GitHub for indexing status", 404);
-    }
-
-    let info = await res.json();
-    let state = "PENDING";
-    if (info.state == "closed") {
-        state = "SUCCESS";
-    } else if (info.comments > 0) {
-        state = "FAILURE"; // any comments indicates failure, otherwise it would just be closed.
-    }
-
-    return new Response(
-        JSON.stringify({ status: state }),
-        {
-            status: 200,
-            headers: { "Content-Type": "application/json" }
-        }
-    );
-})
+router.get("/jobs/:jobid", request => upload.queryJobIdHandler(request, GITHUB_PAT));
 
 /*** Setting up the listener ***/
 
@@ -255,10 +107,9 @@ addEventListener('fetch', event => {
         // Handle CORS preflight requests
         event.respondWith(handleOptions(request));
     } else {
-        event.respondWith(
-            router
-                .handle(request)
-                .catch(error => new Response(error.message || 'Server Error', { status: error.status || 500 }))
-        )
+        let resp = router
+            .handle(request)
+            .catch(error => utils.jsonResponse(error.message || 'Server Error', error.status || 500));
+        event.respondWith(resp);
     }
 })

--- a/index.js
+++ b/index.js
@@ -91,11 +91,15 @@ router.get("/files/:id", async({params, query}) => {
     return Response.redirect(target, 302);
 })
 
-router.post("/projects/:id/version/:version/upload", request => upload.initializeUploadHandler(request, bucket_name, s3));
+router.post("/projects/:id/version/:version/upload", request => upload.initializeUploadHandler(request, bucket_name, s3, GITHUB_PAT));
 
 router.put("/projects/:id/version/:version/complete", request => upload.completeUploadHandler(request, GITHUB_PAT));
 
 router.get("/jobs/:jobid", request => upload.queryJobIdHandler(request, GITHUB_PAT));
+
+/*** Non-standard endpoints, for testing only ***/
+
+router.get("/user", request => auth.isAllowedUploaderHandler(request, GITHUB_PAT));
 
 /*** Setting up the listener ***/
 

--- a/src/auth.js
+++ b/src/auth.js
@@ -1,40 +1,33 @@
 import * as utils from "./utils.js";
 import * as gh from "./github.js";
 
-export async function identifyUser(request) {
+export async function isAllowedUploader(request, master) {
     let auth = request.headers.get("Authorization");
     if (auth == null || !auth.startsWith("Bearer ")) {
-        return null;
+        return utils.errorResponse("no token detected in the Authorization header", 400);
     }
 
     let token = auth.slice(7);
-
-    const tokenCache = await caches.open("token:cache");
-    let key = new Request(request, { cf: { token } })
-    let check = await tokenCache.match(key);
-
-    if (check) {
-        let info = await check.json();
-        return (await info.json()).login;
-    } else {
-        let info = await gh.identifyUser(token);
-        let payload = await info.text();
-        let expiry = new Date(Date.now() + 60 * 60 * 1000);
-        await tokenCache.put(key, new utils.jsonResponse(payload, info.status, { Expires: expiry.toISOString() }))
-        return JSON.parse(payload).login;
-    }
-}
-
-export async function isAllowedUploader(request) {
-    let user = await identifyUser(request);
-    if (user == null) {
-        return utils.errorResponse("failed to determine user from the GitHub token", 401);
+    let user;
+    try {
+        user = await gh.identifyUser(token, master);
+    } catch (e) {
+        return utils.errorResponse("failed to determine user from the GitHub token: " + e.message, 401);
     }
 
-    let allowed = new Set(["LTLA", "lelongs", "jkanche", "PeteHaitch", "vjcitn"]);
+    let allowed = new Set(["ArtifactDB-bot", "LTLA", "lelongs", "jkanche", "PeteHaitch", "vjcitn"]);
     if (!allowed.has(user)) {
         return utils.errorResponse("user '" + user + "' is not in the list of allowed uploaders", 401);
     }
 
     return null;
+}
+
+export async function isAllowedUploaderHandler(request, master) {
+    let resp = await isAllowedUploader(request, master);
+    if (resp === null) {
+        return new Response(null, { status: 204 });
+    } else {
+        return resp;
+    }
 }

--- a/src/auth.js
+++ b/src/auth.js
@@ -1,0 +1,42 @@
+import * as utils from "./utils.js";
+import * as gh from "./github.js";
+
+export async function identifyUser(request) {
+    if (!("Authentication" in request.headers)) {
+        return null;
+    }
+
+    let auth = request.headers["Authentication"];
+    if (!auth.startsWith("Bearer ")) {
+        return null;
+    }
+
+    let token = auth.slice(7);
+
+    const tokenCache = caches.open("token:cache");
+    let check = await tokenCache.match(token);
+    if (check) {
+        let info = await check.json();
+        return info.login;
+    } else {
+        let info = await gh.identifyUser(token);
+        let expiry = new Date(Date.now() + 60 * 60 * 1000);
+        info.headers["Expires"] = expiry.toISOString();
+        tokenCache.put(token, info.clone()); // need to store a clone.
+        return (await info.json()).login;
+    }
+}
+
+export async function isAllowedUploader(request) {
+    let user = await identifyUser(request);
+    if (user == null) {
+        return utils.errorResponse("expected a GitHub PAT in the Authorization header", 401);
+    }
+
+    let allowed = new Set(["LTLA", "lelongs", "jkanche", "PeteHaitch", "vjcitn"]);
+    if (!allowed.has(user)) {
+        return utils.errorResponse("user '" + user + "' is not in the list of allowed uploaders", 401);
+    }
+
+    return null;
+}

--- a/src/auth.js
+++ b/src/auth.js
@@ -2,18 +2,14 @@ import * as utils from "./utils.js";
 import * as gh from "./github.js";
 
 export async function identifyUser(request) {
-    if (!("Authentication" in request.headers)) {
-        return null;
-    }
-
-    let auth = request.headers["Authentication"];
-    if (!auth.startsWith("Bearer ")) {
+    let auth = request.headers.get("Authorization");
+    if (auth == null || !auth.startsWith("Bearer ")) {
         return null;
     }
 
     let token = auth.slice(7);
 
-    const tokenCache = caches.open("token:cache");
+    const tokenCache = await caches.open("token:cache");
     let check = await tokenCache.match(token);
     if (check) {
         let info = await check.json();
@@ -22,7 +18,7 @@ export async function identifyUser(request) {
         let info = await gh.identifyUser(token);
         let expiry = new Date(Date.now() + 60 * 60 * 1000);
         info.headers["Expires"] = expiry.toISOString();
-        tokenCache.put(token, info.clone()); // need to store a clone.
+        tokenCache.put(info.url, info.clone()); // need to store a clone.
         return (await info.json()).login;
     }
 }
@@ -30,7 +26,7 @@ export async function identifyUser(request) {
 export async function isAllowedUploader(request) {
     let user = await identifyUser(request);
     if (user == null) {
-        return utils.errorResponse("expected a GitHub PAT in the Authorization header", 401);
+        return utils.errorResponse("failed to determine user from the GitHub token", 401);
     }
 
     let allowed = new Set(["LTLA", "lelongs", "jkanche", "PeteHaitch", "vjcitn"]);

--- a/src/github.js
+++ b/src/github.js
@@ -44,7 +44,7 @@ export async function identifyUser(token) {
 
     let res = await fetch(URL, {
         headers: {
-            "Authorization": "Bearer " + master,
+            "Authorization": "Bearer " + token,
             "User-Agent": agent
         }
     });
@@ -53,7 +53,7 @@ export async function identifyUser(token) {
         throw new Error("failed to query GitHub for user identity");
     }
 
-    return res.json();
+    return res;
 }
 
 export function createIssueUrl(id) {

--- a/src/github.js
+++ b/src/github.js
@@ -55,3 +55,8 @@ export async function identifyUser(token) {
 
     return res.json();
 }
+
+export function createIssueUrl(id) {
+    return "https://github.com/" + ci_repo + "/issues/" + id;
+}
+

--- a/src/github.js
+++ b/src/github.js
@@ -1,0 +1,57 @@
+const api = "https://api.github.com";
+const ci_repo = "ArtifactDB/gypsum-actions";
+const agent = "gypsum-test-worker";
+
+export async function postNewIssue(title, body, master) {
+    let URL = api + "/repos/" + ci_repo + "/issues";
+
+    let res = await fetch(URL, {
+        method: "POST",
+        headers: {
+            'Content-Type': 'application/json',
+            "Authorization": "Bearer " + master,
+            "User-Agent": agent
+        },
+        "body": JSON.stringify({ title: "upload complete", "body": body })
+    });
+
+    if (!res.ok) {
+        throw new Error("failed to trigger GitHub Actions for indexing");
+    }
+
+    return res;
+}
+
+export async function getIssue(id, master) {
+    let URL = api + "/repos/" + ci_repo + "/issues/" + id;
+
+    let res = await fetch(URL, {
+        headers: {
+            "Authorization": "Bearer " + master,
+            "User-Agent": agent
+        }
+    });
+
+    if (!res.ok) {
+        throw new Error("failed to query GitHub for indexing status");
+    }
+
+    return res;
+}
+
+export async function identifyUser(token) {
+    let URL = api + "/user";
+
+    let res = await fetch(URL, {
+        headers: {
+            "Authorization": "Bearer " + master,
+            "User-Agent": agent
+        }
+    });
+
+    if (!res.ok) {
+        throw new Error("failed to query GitHub for user identity");
+    }
+
+    return res.json();
+}

--- a/src/upload.js
+++ b/src/upload.js
@@ -1,0 +1,95 @@
+import * as auth from "./auth.js";
+import * as utils from "./utils.js";
+import * as gh from "./github.js";
+
+export async function initializeUploadHandler(request, bucket, s3obj) {
+    let id = request.params.id;
+    let version = request.params.version;
+
+    let id_err = await auth.isAllowedUploader(request);
+    if (id_err !== null) {
+        return id_err;
+    }
+
+    let body = await request.json();
+    let files = body.filenames;
+
+    let precollected = [];
+    let prenames = []
+    for (const f of files) {
+        if (typeof f == "string") {
+            let params = { Bucket: bucket, Key: id + "/" + version + "/" + f, Expires: 3600 };
+            if (f.endsWith(".json")) {
+                params.ContentType = "application/json";
+            }
+            precollected.push(s3obj.getSignedUrlPromise('putObject', params));
+            prenames.push(f);
+        } else {
+            return utils.errorResponse("non-string file uploads are not yet supported", 400);
+        }
+    }
+
+    let presigned_vec = await Promise.all(precollected);
+    let presigned = {};
+    for (var i = 0; i < presigned_vec.length; i++) {
+        presigned[prenames[i]] = presigned_vec[i];
+    }
+
+    let completer = "/projects/" + id + "/version/" + version + "/complete";
+    return utils.jsonResponse({ presigned_urls: presigned, completion_url: completer }, 200);
+}
+
+export async function completeUploadHandler(request, master) {
+    let id = request.params.id;
+    let version = request.params.version;
+
+    let id_err = await auth.isAllowedUploader(request);
+    console.log(id_err);
+    if (id_err !== null) {
+        return id_err;
+    }
+
+    // Permissions are handled by the indexer.
+    let perms = await request.json();
+
+    let payload;
+    try {
+        let info = await gh.postNewIssue(
+            "upload complete",
+            JSON.stringify({ 
+                id: id,
+                version: version,
+                timestamp: Date.now(),
+                permissions: perms
+            }),
+            master
+        );
+        payload = await info.json();
+    } catch (e) {
+        return utils.errorResponse(e.message, 500);
+    }
+
+    console.log(payload.number);
+    return utils.jsonResponse({ job_id: payload.number }, 202);
+}
+
+export async function queryJobIdHandler(request, master) {
+    let jid = request.params.jobid;
+
+    let payload;
+    try {
+        let info = await gh.getIssue(jid, master);
+        payload = await info.json();
+    } catch (e) {
+        return utils.errorResponse(e.message, 404);
+    }
+
+    let state = "PENDING";
+    if (payload.state == "closed") {
+        state = "SUCCESS";
+    } else if (payload.comments > 0) {
+        state = "FAILURE"; // any comments indicates failure, otherwise it would just be closed.
+    }
+
+    return utils.jsonResponse({ status: state }, 200);
+}

--- a/src/upload.js
+++ b/src/upload.js
@@ -91,5 +91,8 @@ export async function queryJobIdHandler(request, master) {
         state = "FAILURE"; // any comments indicates failure, otherwise it would just be closed.
     }
 
-    return utils.jsonResponse({ status: state }, 200);
+    return utils.jsonResponse({ 
+        status: state,
+        job_url: gh.createIssueUrl(jid)
+    }, 200);
 }

--- a/src/upload.js
+++ b/src/upload.js
@@ -69,7 +69,6 @@ export async function completeUploadHandler(request, master) {
         return utils.errorResponse(e.message, 500);
     }
 
-    console.log(payload.number);
     return utils.jsonResponse({ job_id: payload.number }, 202);
 }
 

--- a/src/upload.js
+++ b/src/upload.js
@@ -2,11 +2,11 @@ import * as auth from "./auth.js";
 import * as utils from "./utils.js";
 import * as gh from "./github.js";
 
-export async function initializeUploadHandler(request, bucket, s3obj) {
+export async function initializeUploadHandler(request, bucket, s3obj, master) {
     let id = request.params.id;
     let version = request.params.version;
 
-    let id_err = await auth.isAllowedUploader(request);
+    let id_err = await auth.isAllowedUploader(request, master);
     if (id_err !== null) {
         return id_err;
     }
@@ -43,7 +43,7 @@ export async function completeUploadHandler(request, master) {
     let id = request.params.id;
     let version = request.params.version;
 
-    let id_err = await auth.isAllowedUploader(request);
+    let id_err = await auth.isAllowedUploader(request, master);
     console.log(id_err);
     if (id_err !== null) {
         return id_err;

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,0 +1,35 @@
+export function unpackId(id) {
+    let i1 = id.indexOf(":");
+    if (i1 < 0) {
+        throw new Error("could not identify project from 'id'");
+    } else if (i1 == 0) {
+        throw new Error("'id' should not have an empty project");
+    }
+
+    let i2 = id.lastIndexOf("@");
+    if (i2 < 0) {
+        throw new Error("could not identify version from 'id'");
+    } else if (i2 == id.length - 1) {
+        throw new Error("'id' should not have an empty version");
+    }
+
+    if (i2 < i1) {
+        throw new Error("could not identify version from 'id'");
+    } else if (i1 +1 == i2){
+        throw new Error("'id' should not have an empty path");
+    }
+
+    return {
+        project: id.slice(0, i1),
+        path: id.slice(i1+1, i2),
+        version: id.slice(i2+1)
+    };
+}
+
+export function jsonResponse(x, code, headers={}) {
+    return new Response(JSON.stringify(x), { "status": code, "headers": { ...headers, "Content-Type": "application/json" } });
+}
+
+export function errorResponse(reason, code, headers={}) {
+    return jsonResponse({ "status": "error", "reason": reason }, code, headers);
+}


### PR DESCRIPTION
Fortunately R2 has pretty good S3 compatibility, so we can just return presigned
URLs from /upload instead of managing the uploads via the API. The /complete
endpoint uses GHAs in ArtifactDB/gypsum-actions to do all the pseudo-indexing.