### PR TITLE
Resolve the 'latest' alias in all version-specific getter endpoints.

### DIFF
--- a/src/files.js
+++ b/src/files.js
@@ -90,7 +90,7 @@ export async function getFileMetadataHandler(request, bound_bucket, globals, non
         let file_res;
         let file_meta_fun = v => bound_bucket.get(unpacked.project + "/" + v + "/" + unpacked.path);
         if (unpacked.version == "latest") {
-            let attempt = await latest.attemptOnLatest(unpacked.project, bound_bucket, file_meta_fun, res => res == null);
+            let attempt = await latest.attemptOnLatest(unpacked.project, bound_bucket, file_meta_fun, nonblockers);
             file_res = attempt.result;
             unpacked.version = attempt.version;
         } else {
@@ -175,7 +175,7 @@ export async function getFileHandler(request, bound_bucket, globals, nonblockers
         let header;
         let file_header_fun = v => bound_bucket.head(unpacked.project + "/" + v + "/" + unpacked.path);
         if (unpacked.version == "latest") {
-            let attempt = await latest.attemptOnLatest(unpacked.project, bound_bucket, file_header_fun, res => res == null);
+            let attempt = await latest.attemptOnLatest(unpacked.project, bound_bucket, file_header_fun, nonblockers);
             header = attempt.result;
             unpacked.version = attempt.version;
         } else {

--- a/src/internal.js
+++ b/src/internal.js
@@ -6,8 +6,12 @@ export function versionMetadata(project, version) {
     return project + "/" + version + "/..revision";
 }
 
-export function latest(project) {
+export function latestPersistent(project) {
     return project + "/..latest";
+}
+
+export function latestAll(project) {
+    return project + "/..latest_all";
 }
 
 export function lock(project, version) {

--- a/src/latest.js
+++ b/src/latest.js
@@ -28,7 +28,6 @@ function latest_cache_key(project) {
 }
 
 export async function getLatestVersion(project, bound_bucket, nonblockers) {
-    console.log("YAY2");
     const latestCache = await latest_cache();
 
     let key = latest_cache_key(project);

--- a/src/latest.js
+++ b/src/latest.js
@@ -1,0 +1,83 @@
+import * as pkeys from "./internal.js";
+
+export async function get_latest_version_from_source(project, bound_bucket, cache, cache_key, nonblockers) {
+    let stuff = await bound_bucket.get(pkeys.latestAll(project));
+    if (stuff == null) {
+        throw new utils.HttpError("failed to retrieve latest version for project '" + project + "'", 404);
+    }
+
+    let data = await stuff.text();
+    let output = JSON.parse(data);
+
+    if (output.version == "") {
+        throw new utils.HttpError("all versions of project '" + project + "' have expired", 404);
+    }
+
+    nonblockers.push(utils.quickCacheJsonText(cache, cache_key, data, utils.minutesFromNow(5)));
+    return output;
+}
+
+function latest_cache() {
+    return caches.open("latest:cache");
+}
+
+function latest_cache_key(project) {
+    // Key needs to be a URL.
+    return "https://github.com/ArtifactDB/gypsum-worker/latest/" + project;
+}
+
+export async function getLatestVersion(project, bound_bucket, nonblockers) {
+    const latestCache = await latest_cache();
+
+    let key = latest_cache_key(project);
+    let check = await latestCache.match(key);
+    if (check) {
+        return await check.json();
+    }
+
+    return await get_latest_version_from_source(project, bound_bucket, latestCache, key, nonblockers);
+}
+
+export async function getLatestPersistentVersionOrNull(project, bound_bucket) {
+    // Don't bother to cache this, as (i) it's only required for upload start
+    // and (ii) we always want to get the very latest from source anyway when
+    // defining links to write to the bucket.
+    let stuff = await bound_bucket.get(pkeys.latestPersistent(project));
+    if (stuff == null) {
+        return null;
+    }
+    return await stuff.json();
+}
+
+export async function attemptOnLatest(project, bound_bucket, fun, fail, nonblockers) {
+    const latestCache = await latest_cache();
+
+    let key = latest_cache_key(project);
+    let check = await latestCache.match(key);
+
+    // If nothing was cached, the latest ID must be fetched from source directly,
+    // in which case we don't have to worry about cache invalidity.
+    if (check == null) {
+        let latest = await get_latest_version_from_source(project, bound_bucket, latestCache, key, nonblockers);
+        let lv = latest.version;
+        return { version: lv, result: fun(lv) };
+    }
+
+    // Attempting to run the supplied function on the latest version in cache.
+    {
+        let latest = await check.json();
+        let lv = latest.version;
+        let res = await fun(lv);
+        if (!fail(res)) {
+            return { version: lv, result: fun(lv) };
+        }
+    }
+
+    // If that fails, e.g., due to the removal of an expired version, we flush
+    // the cache, re-acquire the latest version again, and re-run the function.
+    // If that ALSO fails... you're on your own.
+    await latestCache.delete(key);
+    let latest = await get_latest_version_from_source(project, bound_bucket, latestCache, key, nonblockers);
+    let lev = latest.version;
+    return { version: lv, result: fun(lv) };
+}

--- a/src/latest.js
+++ b/src/latest.js
@@ -1,3 +1,4 @@
+import * as utils from "./utils.js";
 import * as pkeys from "./internal.js";
 
 export async function get_latest_version_from_source(project, bound_bucket, cache, cache_key, nonblockers) {
@@ -27,6 +28,7 @@ function latest_cache_key(project) {
 }
 
 export async function getLatestVersion(project, bound_bucket, nonblockers) {
+    console.log("YAY2");
     const latestCache = await latest_cache();
 
     let key = latest_cache_key(project);
@@ -49,7 +51,7 @@ export async function getLatestPersistentVersionOrNull(project, bound_bucket) {
     return await stuff.json();
 }
 
-export async function attemptOnLatest(project, bound_bucket, fun, fail, nonblockers) {
+export async function attemptOnLatest(project, bound_bucket, fun, nonblockers) {
     const latestCache = await latest_cache();
 
     let key = latest_cache_key(project);
@@ -60,7 +62,7 @@ export async function attemptOnLatest(project, bound_bucket, fun, fail, nonblock
     if (check == null) {
         let latest = await get_latest_version_from_source(project, bound_bucket, latestCache, key, nonblockers);
         let lv = latest.version;
-        return { version: lv, result: fun(lv) };
+        return { version: lv, result: await fun(lv) };
     }
 
     // Attempting to run the supplied function on the latest version in cache.
@@ -68,8 +70,8 @@ export async function attemptOnLatest(project, bound_bucket, fun, fail, nonblock
         let latest = await check.json();
         let lv = latest.version;
         let res = await fun(lv);
-        if (!fail(res)) {
-            return { version: lv, result: fun(lv) };
+        if (res != null) {
+            return { version: lv, result: res };
         }
     }
 
@@ -79,5 +81,5 @@ export async function attemptOnLatest(project, bound_bucket, fun, fail, nonblock
     await latestCache.delete(key);
     let latest = await get_latest_version_from_source(project, bound_bucket, latestCache, key, nonblockers);
     let lev = latest.version;
-    return { version: lv, result: fun(lv) };
+    return { version: lv, result: await fun(lv) };
 }

--- a/src/project.js
+++ b/src/project.js
@@ -271,7 +271,7 @@ export async function getProjectVersionInfoHandler(request, bound_bucket, global
             return utils.jsonResponse({ 
                 status: "error", 
                 permissions: resolved.permissions,
-                reasons: ["project version is still locked"]
+                anomalies: ["project version is still locked"]
             }, 200);
         }
         ver_meta = await check_version_meta(version);
@@ -285,7 +285,7 @@ export async function getProjectVersionInfoHandler(request, bound_bucket, global
         return utils.jsonResponse({ 
             status: "error", 
             permissions: resolved.permissions, 
-            reasons: ["cannot find version metadata"]
+            anomalies: ["cannot find version metadata"]
         }, 200);
     }
 


### PR DESCRIPTION
This uses a two-pass strategy to handle cases where the cached latest version
has been deleted. Specifically, we try to get the resource using the cached
latest, and if that fails, we delete the cache and reload the latest version
from R2. This ensures that the resolution is robust to loss of versions due to
expiry, though you'll still have to wait for normal cache expiration if a new
latest version is added.

The project information endpoint has also been updated so that locking or lack
of version metadata results in a 200 return with a status: error and some
information in the anomalies property. Note that this endpoint is also
version-specific and so responds properly to the 'latest' alias.